### PR TITLE
Fix MyOrders table display, payment types services

### DIFF
--- a/data/payment-types.js
+++ b/data/payment-types.js
@@ -1,7 +1,7 @@
 import { fetchWithResponse, fetchWithoutResponse } from "./fetcher";
 
 export function getPaymentTypes() {
-  return fetchWithResponse('payment-types', {
+  return fetchWithResponse('paymenttypes', {
     headers: {
       Authorization: `Token ${localStorage.getItem('token')}`
     }
@@ -9,7 +9,7 @@ export function getPaymentTypes() {
 }
 
 export function addPaymentType(paymentType) {
-  return fetchWithResponse(`payment-types`, {
+  return fetchWithResponse(`paymenttypes`, {
     method: 'POST',
     headers: {
       Authorization: `Token ${localStorage.getItem('token')}`,
@@ -20,7 +20,7 @@ export function addPaymentType(paymentType) {
 }
 
 export function deletePaymentType(id) {
-  return fetchWithoutResponse(`payment-types/${id}`, {
+  return fetchWithoutResponse(`paymenttypes/${id}`, {
     method: 'DELETE',
     headers: {
       Authorization: `Token ${localStorage.getItem('token')}`

--- a/pages/my-orders.js
+++ b/pages/my-orders.js
@@ -9,7 +9,7 @@ import { getPaymentTypes } from '../data/payment-types'
 export default function Orders() {
   const [orders, setOrders] = useState([])
   const [paymentTypes, setPaymentTypes] = useState([])
-  const [isLoading, setIsLoading] = useState(true); // Add a loading state
+  const [isLoading, setIsLoading] = useState(true); //Loading state
   const headers = ['Order Date', 'Total', 'Payment Method']
 
   useEffect(() => {
@@ -47,7 +47,9 @@ export default function Orders() {
             let paymentTypeName = "No payment type recorded."; // Default value
 
   if (order.payment_type!== null) {
+    //Parse payment_type url string to extract trailing identifier (id)
     const paymentTypeId = order.payment_type.split('/').pop();
+    //Matching payment type is located in state by id
     const paymentType = paymentTypes.find(pt => pt.id === parseInt(paymentTypeId));
     paymentTypeName = paymentType? paymentType.merchant_name : "Unknown Payment Type";
   }

--- a/pages/my-orders.js
+++ b/pages/my-orders.js
@@ -4,32 +4,63 @@ import Layout from '../components/layout'
 import Navbar from '../components/navbar'
 import Table from '../components/table'
 import { getOrders } from '../data/orders'
+import { getPaymentTypes } from '../data/payment-types'
 
 export default function Orders() {
   const [orders, setOrders] = useState([])
+  const [paymentTypes, setPaymentTypes] = useState([])
+  const [isLoading, setIsLoading] = useState(true); // Add a loading state
   const headers = ['Order Date', 'Total', 'Payment Method']
 
   useEffect(() => {
-    getOrders().then(ordersData => {
+    Promise.all([
+      getOrders(),
+      getPaymentTypes()
+    ]).then(([ordersData, paymentData]) => {
       if (ordersData) {
-        setOrders(ordersData)
+        setOrders(ordersData);
       }
-    })
-  }, [])
+      if (paymentData) {
+        setPaymentTypes(paymentData);
+      }
+      setIsLoading(false); // Set loading to false once both promises resolve
+    });
+  }, []);
+
+  if (isLoading) {
+    return <div>Loading...</div>; 
+  }
 
   return (
     <>
       <CardLayout title="Your Orders">
         <Table headers={headers}>
-          {
-            orders.map((order) => (
+        {
+          orders.map((order) => {
+            // Calculate total price across all line items
+            let totalPrice = 0;
+            if (order.lineitems && order.lineitems.length > 0) {
+              order.lineitems.forEach(item => {
+                totalPrice += item.product.price;
+              });
+            }
+            let paymentTypeName = "No payment type recorded."; // Default value
+
+  if (order.payment_type!== null) {
+    const paymentTypeId = order.payment_type.split('/').pop();
+    const paymentType = paymentTypes.find(pt => pt.id === parseInt(paymentTypeId));
+    paymentTypeName = paymentType? paymentType.merchant_name : "Unknown Payment Type";
+  }
+
+            return (
               <tr key={order.id}>
-                <td>{order.completed_on}</td>
-                <td>${order.total}</td>
-                <td>{order.payment_type?.obscured_num}</td>
+                <td>{order.created_date}</td>
+                <td>${totalPrice.toFixed(2)}</td> 
+                <td>{paymentTypeName}</td>
               </tr>
-            ))
-          }
+            );
+          })
+}
         </Table>
         <></>
       </CardLayout>


### PR DESCRIPTION
This PR fixes the MyOrders table display so that orders are properly parsed and displayed.

Changes:
Payment types services were fixed to point to the paymenttypes endpoint
Promise.all() and a loading state flag are used to prevent async issues
Order lineitems are summed to find total order price
Payment_type url strings are now parsed for id and the matching payment type is retrieved from the API
Payment types are now retrieved and used in state to resolve merchant_name for orders
Added conditional logic to validate data

Testing:
Tested with multiple users/orders
