### PR TITLE
Feature: All Stores View is Accessible 

### DIFF
--- a/components/store/card.js
+++ b/components/store/card.js
@@ -16,6 +16,9 @@ export function StoreCard({ store, width= "is-half" }) {
           <div className="content">
             {store.description}
           </div>
+          <div className="content">
+            Currently Selling {store.products?.length} Products
+          </div>
         </div>
         <footer className="card-footer">
           <Link href={`stores/${store.id}`}>

--- a/components/store/card.js
+++ b/components/store/card.js
@@ -11,7 +11,7 @@ export function StoreCard({ store, width= "is-half" }) {
         </header>
         <div className="card-content">
           <p className="content">
-            Owner: {store.seller.first_name} {store.seller.last_name}
+            Owner: {store.customer.user.first_name} {store.customer.user.last_name}
           </p>
           <div className="content">
             {store.description}


### PR DESCRIPTION
## What?
When a user clicks "Stores" from the navbar, they are taken to a view that lists all of the current stores, the store name, a description, and the owner.
## Why?
A Bangazon user should be able to see a list of all stores currently selling products.
## How?
The store card file needed to be updated in order to access the necessary values. The name of the store's owner is now accessed on 
```
store.customer.user.first_name 
```
and 
```
store.customer.user.last_name
```
## Testing?
Please test in browser
## Screenshots (optional)
0
## Anything Else?
Ticket #36 is still in progress. Still need to implement the correct number of items a store has for sale and a way to preview products for each store. The PR was created, however, to remove potential blockers.