### PR TITLE
Implement new product listing

### DIFF
--- a/components/product/form.js
+++ b/components/product/form.js
@@ -3,8 +3,10 @@ import { getCategories } from '../../data/products'
 import CardLayout from '../card-layout'
 import { Textarea, Select, Input } from '../form-elements'
 
+
 export default function ProductForm({ formEl, saveEvent, title, router }) {
   const [categories, setCategories] = useState([])
+
 
   useEffect(() => {
     getCategories().then(catData => setCategories(catData))
@@ -39,6 +41,10 @@ export default function ProductForm({ formEl, saveEvent, title, router }) {
           id="quantity"
           label="Quantity"
           type="number"
+        />
+        <Input
+          id="image_path"
+          label="Image path"
         />
       </form>
       <>

--- a/data/fetcher.js
+++ b/data/fetcher.js
@@ -8,7 +8,7 @@ const checkError = (res) => {
 }
 
 const checkErrorJson = (res) => {
-  if (res.status !== 200) {
+  if (res.status !== 200 && res.status!==201) {
     throw Error(res.status);
   } else {
     return res.json()

--- a/data/products.js
+++ b/data/products.js
@@ -94,22 +94,6 @@ export function addProduct(product) {
   })
 }
 
-// export async function addProduct(product) {
-//   const response = await fetch('products', {
-//     method: 'POST',
-//     headers: {
-//       'Content-Type': 'application/json',
-//     },
-//     body: JSON.stringify(product),
-//   });
-
-//   if (!response.ok) {
-//     throw new Error('Failed to add product');
-//   }
-
-//   return response.json(); 
-// }
-
 export function editProduct(id, product) {
   return fetchWithoutResponse(`products/${id}`, {
     method: 'PUT',

--- a/data/products.js
+++ b/data/products.js
@@ -94,6 +94,22 @@ export function addProduct(product) {
   })
 }
 
+// export async function addProduct(product) {
+//   const response = await fetch('products', {
+//     method: 'POST',
+//     headers: {
+//       'Content-Type': 'application/json',
+//     },
+//     body: JSON.stringify(product),
+//   });
+
+//   if (!response.ok) {
+//     throw new Error('Failed to add product');
+//   }
+
+//   return response.json(); 
+// }
+
 export function editProduct(id, product) {
   return fetchWithoutResponse(`products/${id}`, {
     method: 'PUT',

--- a/pages/products/new.js
+++ b/pages/products/new.js
@@ -4,22 +4,41 @@ import Layout from '../../components/layout'
 import Navbar from '../../components/navbar'
 import { addProduct } from '../../data/products'
 import ProductForm from '../../components/product/form'
+import { useAppContext } from '../../context/state'
+
 export default function NewProduct() {
   const formEl = useRef()
   const router = useRouter()
+  const { token, profile } = useAppContext()
 
-  const saveProduct = () => {
-    const { name, description, price, category, location, quantity  } = formEl.current
+  const saveProduct = async () => {
+
+    const { name, description, price, category, location, quantity, image_path  } = formEl.current
     const product = {
       name: name.value,
       description: description.value,
       price: price.value,
-      categoryId: category.value,
+      category_id: parseInt(category.value),
       location: location.value,
-      quantity: quantity.value
+      quantity: quantity.value,
+      image_path: image_path.value,
+      store_id: profile.store_owned.id
     }
-    addProduct(product).then((res) => router.push(`/products/${res.id}`))
-  }
+    try {
+      const res = await addProduct(product);
+      if (res && res.id) {
+        
+        setTimeout(() => {
+          router.push(`/products/${res.id}`);
+        }, 100); // 100ms delay
+      } else {
+        console.error("Unexpected response structure:", res);
+      }
+    } catch (error) {
+      console.error("Error creating product:", error);
+    }
+  };
+  
 
   return (
     <ProductForm

--- a/pages/stores/[id]/index.js
+++ b/pages/stores/[id]/index.js
@@ -15,6 +15,17 @@ export default function StoreDetail() {
   const [store, setStore] = useState({})
   const [soldProducts, setSoldProducts] = useState([])
   const [isOwner, setIsOwner] = useState(false)
+  const [uniqueSoldProductIds, setUniqueSoldProductIds] = useState({});
+
+  useEffect(() => {
+    let newUniqueIds = {};
+    [...soldProducts].forEach((product, index) => {
+      // Generate a unique key by combining the array name, product ID, and index
+      const key = `${product.arrayName}-${product.id}-${index}`;
+      newUniqueIds[product.id] = key;
+    });
+    setUniqueSoldProductIds(newUniqueIds);
+  }, [store.products, soldProducts]);
 
   useEffect(() => {
     if (id) {
@@ -81,7 +92,7 @@ export default function StoreDetail() {
 
             <ProductCard
               product={product.product}
-              key={product.product.id}
+              key={uniqueSoldProductIds[product.id]}
             />
           ))
         }


### PR DESCRIPTION
This PR implements the ability for a user to list a new item in their store

---

Given that the user wants to list an item, once the user selects "Add a new product" from the navbar, they are navigated to a new product form

Given that the user has entered all required fields for a new product, when the user selects the 'Save" button, the product is saved to the database and the user is navigated to the new product page

---

Updates products/new.js New Product form to work with API
Fix fetcher.js to account for status 201
Implements state management to ensure proper response before navigation
Updates form to provide store_id for API POST via app context
Fixes key assignment for sold items on the MyStore page (at /stores/{id}) 

---

Testing:
Tested with a number of new products