### PR TITLE
Bug Fix: Completing order working

### DIFF
--- a/data/orders.js
+++ b/data/orders.js
@@ -17,12 +17,12 @@ export function getOrders() {
 }
 
 export function completeCurrentOrder(orderId, paymentTypeId) {
-  return fetchWithResponse(`orders/${orderId}/complete`, {
+  return fetchWithResponse(`orders/${orderId}`, {
     method: 'PUT',
     headers: {
       Authorization: `Token ${localStorage.getItem('token')}`,
       'Content-Type': 'application/json'
     },
-    body: JSON.stringify({paymentTypeId})
+    body: JSON.stringify({ payment_type_id: paymentTypeId })
   })
 }


### PR DESCRIPTION
## Changes 
#### `order.js`
- modified the `completeCurrentOrder` fetch URL to `orders/${orderId}`
- created `JSON.stringify({ payment_type_id: paymentTypeId })` so the API knows what payment id to use for the order 

## Testing
- [ ] Pull the API and Client side changes down 
- [ ] Start Servers
- [ ] Add products to cart 
- [ ] Complete Order
- [ ] Verify the Order is in the `my-orders` view
- [ ] Check the DB to make sure the payment id is in the orders table and a new order has been created under it


## Related Issues
- Fixes #33 