### PR TITLE
Add recommendations display to profile page

### DIFF
--- a/pages/profile.js
+++ b/pages/profile.js
@@ -33,7 +33,7 @@ export default function Profile() {
       <CardLayout title="Products you've recommended" width="is-full">
         <div className="columns is-multiline">
           {
-            profile.recommended_by?.map(recommendation => (
+            profile.recommends?.map(recommendation => (
               <ProductCard product={recommendation.product} key={recommendation.product.id} width="is-one-third" />
             ))
           }
@@ -43,7 +43,7 @@ export default function Profile() {
       <CardLayout title="Products recommended to you" width="is-full">
         <div className="columns is-multiline">
           {
-            profile.recommendations?.map(recommendation => (
+            profile.recommended?.map(recommendation => (
               <ProductCard product={recommendation.product} key={recommendation.product.id} width="is-one-third" />
             ))
           }


### PR DESCRIPTION
This PR implements display of recommendations both given and received by a user

Given a user wants to see recommended products, when the user navigates to Profile in the nav bar, a list of products recommended by the user as well as a list of products recommended to the user are displayed

---

Changes:

Adjusts profile.py to work with API profile response

---

Testing:
Tested with user profile