### PR TITLE
Fixed Registering a New User

### DIFF
--- a/pages/register.js
+++ b/pages/register.js
@@ -14,6 +14,9 @@ export default function Register() {
   const lastName = useRef('')
   const username = useRef('')
   const password = useRef('')
+  const email = useRef('')
+  const phoneNumber = useRef('')
+  const address = useRef('')
   const router = useRouter()
 
   const submit = (e) => {
@@ -23,7 +26,10 @@ export default function Register() {
       username: username.current.value,
       password: password.current.value,
       first_name: firstName.current.value,
-      last_name: lastName.current.value
+      last_name: lastName.current.value,
+      email: email.current.value,
+      phone_number: phoneNumber.current.value,
+      address: address.current.value
     }
 
     register(user).then((res) => {
@@ -63,6 +69,24 @@ export default function Register() {
             refEl={password}
             type="password"
             label="Password"
+          />
+          <Input
+            id="email"
+            refEl={email}
+            type="text"
+            label="Email"
+          />
+          <Input
+            id="phoneNumber"
+            refEl={phoneNumber}
+            type="text"
+            label="Phone Number"
+          />
+          <Input
+            id="address"
+            refEl={address}
+            type="text"
+            label="Address"
           />
 
           <div className="field is-grouped">


### PR DESCRIPTION
## What?
I have fixed a bug that would not allow a new user to register and create an account. Now, when a user who does not have an account creates one, they become an authenticated user.
## Why?
Previously, if a new user inputted the required information to create an account and clicked "submit," an error was returned and the new user was not added to the database. 
## How?
The Register function needed to be updated to include email, phone number, and address of a user as these properties were required by the api. I also updated the register form to include an input field for each of these values.
## Testing?
-npm run dev
-make sure debugger is running on api side
-in browser, log out if already logged in, click "sign up" button and fill out the register form
-click submit, and a 201 created status code will be returned
-double check database to ensure the new user has been added.
## Screenshots (optional)
0
## Anything Else?
a 500 internal servor error is also returned for Profile. The preview tab states: no such column: bangazonapi_payment.created_date. This error does not seem to impact the registering of a new user and may need to be addressed on a seperate ticket. 