### PR TITLE
Only stores with products are visible in all-stores view

### DIFF
--- a/components/store/card.js
+++ b/components/store/card.js
@@ -2,6 +2,9 @@ import React from 'react'
 import Link from 'next/link'
 
 export function StoreCard({ store, width= "is-half" }) {
+  if (!store.products || store.products.length === 0) {
+    return null
+  }
   const previewProducts = () => {
     const products = store.products || []
     return products.length > 5? products.slice(0, 5) : products


### PR DESCRIPTION
## What?
Given that a user clicks the Stores link to view all stores, they will only see stores with products available.
## Why?
This update enhances the user's experience by displaying a page free from clutter and potential ghost stores that, while created, are not actively selling anything.
## How?
A simple if statement checks to see if the products of the store is undefined or if the number of products is equal to zero. If this is true, it returns null and the store is not displayed. If this is not the case and the products of the store exist and are not equal to zero, the store will be displayed in the all stores view.
## Testing?
Test in Browser:
--run debugger in API and 
```
npm run dev 
```
in client
--choose "Stores" from the dropdown and verify that all stores are actively selling products. 
--log in as a user that has a store w/o products (you may need to create this for your own database and that can be done from the browser. Register a new user, click the "interested in selling" link, create a store in the store form, verify in DB that the user and store was created)
--verify that the store does not appear in the all-stores view, but that the owner of the store can still view the store's details page by clicking "view your store" from the dropdown"
## Screenshots (optional)
0
## Anything Else?
