### PR TITLE
Btn toggle for like/dislike working

### DIFF
--- a/components/product/detail.js
+++ b/components/product/detail.js
@@ -4,7 +4,7 @@ import { addProductToOrder, recommendProduct } from "../../data/products"
 import Modal from "../modal"
 import { Input } from "../form-elements"
 
-export function Detail({ product, like, unlike }) {
+export function Detail({ product, like, unlike, likes }) {
   const router = useRouter()
   const usernameEl = useRef()
   const [showModal, setShowModal] = useState(false)
@@ -28,6 +28,8 @@ export function Detail({ product, like, unlike }) {
       }
     })
   }
+
+  const isLiked = likes.some(likedProduct => likedProduct.id === product.id)
 
   return (
     <>
@@ -68,9 +70,10 @@ export function Detail({ product, like, unlike }) {
                   onClick={() => setShowModal(true)}
                 >Recommend this Product</button>
               </p>
+
               <p className="control">
                 {
-                  product.is_liked ?
+                  isLiked ?
                     <button className="button is-link is-outlined" onClick={unlike}>
                       <span className="icon is-small">
                         <i className="fas fa-heart-broken"></i>
@@ -86,6 +89,7 @@ export function Detail({ product, like, unlike }) {
                     </button>
                 }
               </p>
+
             </div>
           </article>
         </div>

--- a/data/products.js
+++ b/data/products.js
@@ -116,6 +116,18 @@ export function recommendProduct(id, username) {
   })
 }
 
+//! --------------------------- Like - Unlike Product
+
+export function getLikedProducts() {
+  return fetchWithResponse(`products/liked`, {
+    method: 'GET',
+    headers: {
+      Authorization: `Token ${localStorage.getItem('token')}`,
+      'Content-Type': 'application/json'
+    }
+  })
+}
+
 export function likeProduct(productId) {
   return fetchWithoutResponse(`products/${productId}/like`, {
     method: 'POST',
@@ -127,7 +139,7 @@ export function likeProduct(productId) {
 }
 
 export function unLikeProduct(productId) {
-  return fetchWithoutResponse(`products/${productId}/unlike`, {
+  return fetchWithoutResponse(`products/${productId}/like`, {
     method: 'DELETE',
     headers: {
       Authorization: `Token ${localStorage.getItem('token')}`,
@@ -135,6 +147,8 @@ export function unLikeProduct(productId) {
     },
   })
 }
+
+
 
 export const getSoldProductsForStore = (storeId) => {
   return fetchWithResponse(`storeproduct?store=${storeId}`, {

--- a/pages/products/[id]/index.js
+++ b/pages/products/[id]/index.js
@@ -4,12 +4,15 @@ import Layout from '../../../components/layout'
 import Navbar from '../../../components/navbar'
 import { Detail } from '../../../components/product/detail'
 import { Ratings } from '../../../components/rating/detail'
-import { getProductById, likeProduct, unLikeProduct } from '../../../data/products'
+import { getProductById, likeProduct, unLikeProduct, getLikedProducts } from '../../../data/products'
+import { getUserProfile } from '../../../data/auth.js'
+
 
 export default function ProductDetail() {
   const router = useRouter()
   const { id } = router.query
   const [product, setProduct] = useState({})
+  const [likes, setLikes] = useState([])
 
   const refresh = () => {
     getProductById(id).then(productData => {
@@ -19,24 +22,43 @@ export default function ProductDetail() {
     })
   }
 
+  const getUserLikes = () => {
+    getLikedProducts().then((likedProducts) => {
+      setLikes(likedProducts)
+    })
+  }
+
   const like = () => {
-    likeProduct(id).then(refresh)
+    likeProduct(id).then(() => {
+      getUserLikes()
+      refresh()
+      console.log("Product liked:", product) 
+    })
   }
 
   const unlike = () => {
-    unLikeProduct(id).then(refresh)
+    unLikeProduct(id).then(() => {
+      getUserLikes()
+      refresh()
+      console.log("Product unliked:", product) 
+    })
   }
 
   useEffect(() => {
     if (id) {
       refresh()
+      getUserProfile().then((profileData) => {
+        if (profileData) {
+          getUserLikes()
+        }
+      })
     }
   }, [id])
 
   return (
     <div className="columns is-centered">
       <div className="column">
-        <Detail product={product} like={like} unlike={unlike}/>
+        <Detail product={product} like={like} unlike={unlike} likes={likes}/>
         <Ratings
           refresh={refresh}
           number_purchased={product.number_purchased}

--- a/pages/profile.js
+++ b/pages/profile.js
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import CardLayout from '../components/card-layout'
 import Layout from '../components/layout'
 import Navbar from '../components/navbar'
@@ -6,17 +6,24 @@ import { ProductCard } from '../components/product/card'
 import { StoreCard } from '../components/store/card'
 import { useAppContext } from '../context/state'
 import { getUserProfile } from '../data/auth'
+import { getLikedProducts } from '../data/products.js'
 
 export default function Profile() {
   const { profile, setProfile } = useAppContext()
+  const [likes, setLikes] = useState([])
 
   useEffect(() => {
     getUserProfile().then((profileData) => {
       if (profileData) {
+        console.log(profileData)
+        getLikedProducts().then((likedProducts) => {
+          setLikes(likedProducts)
+          console.log(likedProducts)
+        })
         setProfile(profileData)
       }
     })
-  }, [])
+  }, [setProfile])
 
   return (
     <>
@@ -54,7 +61,7 @@ export default function Profile() {
       <CardLayout title="Products you've liked" width="is-full">
         <div className="columns is-multiline">
           {
-            profile.likes?.map(product => (
+            likes.map(product => (
               <ProductCard product={product} key={product.id} width="is-one-third" />
             ))
           }


### PR DESCRIPTION
## Overview 
Implemented functionality that allows the user to like / dislike products and change the btn for each situation. 

### Files Changes
- `product/detail.js`
- - Checks the likes to see if at least 1 matches the current `product.id` 
- - Conditionally renders btn if product is liked or not 
- `data/products.js`
- - Created `getLikedProducts` function and updated URL for `unLikeProduct`
- `products/[id]/index.js`
- - pass `likes` as prop to `detail.js` and reloads state `setLikes` when a user likes / dislikes a product
- `pages/profile.js`
- - Get the user liked products, `.map()` through the products and display them on the profile

### Testing 
- [x] Pull down Client and API side 
- [x] Load servers 
- [x] Sign in with user that has liked products 
- [x] Go to `Profile` and make sure the products are showing up under the `Liked Products` section 
- [x] Go to a Store and like / unlike a product and verify the btn has changed and the new product has been added to your profile / taken off 